### PR TITLE
[FIX] crash due to an error in minimum_cycle_basis

### DIFF
--- a/crmodel/utils.py
+++ b/crmodel/utils.py
@@ -132,6 +132,8 @@ def getIslands(G, branches, crossroad_border_nodes):
             neighbors = list(set(tG.neighbors(to_handle)).intersection(cycle))
             if len(neighbors) > 0:
                 to_handle = neighbors[0]
+            else:
+                break
         faces.append(ordered)
 
     return faces


### PR DESCRIPTION
minimum_cycle_basis may return a cycle with supplementary ones that are not in the cycle. 

Example: 45.747393 3.070882

Implemented solution: skip remaining points.

